### PR TITLE
Automatic describe route for metas

### DIFF
--- a/src/describe.js
+++ b/src/describe.js
@@ -1,0 +1,5 @@
+module.exports.subscribeToDescribe = function (carotte, qualifier, meta) {
+    carotte.subscribe(`${qualifier}:describe`, () => {
+        return meta;
+    });
+};

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const debug = require('debug');
 const Puid = require('puid');
 const amqp = require('amqplib');
 const bouillonAgent = require('./bouillon-agent');
+const describe = require('./describe');
 const carottePackage = require('../package');
 
 const { EXCHANGE_TYPE, EXCHANGES_AVAILABLE } = require('./constants');
@@ -43,7 +44,8 @@ function Carotte(config) {
         host: 'localhost:5672',
         enableBouillon: false,
         deadLetter: 'dead-letter',
-        enableDeadLetter: false
+        enableDeadLetter: false,
+        autoDescribe: false
     }, config);
 
     const carotte = {};
@@ -267,6 +269,9 @@ function Carotte(config) {
 
         if (meta) {
             bouillonAgent.addSubscriber(qualifier, meta);
+            if (config.autoDescribe) {
+                describe.subscribeToDescribe(this, qualifier, meta);
+            }
         } else {
             meta = { timer: {} };
         }

--- a/tests/describe.spec.js
+++ b/tests/describe.spec.js
@@ -1,0 +1,18 @@
+const expect = require('chai').expect;
+const carotte = require('../src')({
+    autoDescribe: true
+});
+
+describe('describe', () => {
+    it('should expose metas on a direct route using a :describe suffix', () => {
+        carotte.subscribe('hello-to-you-describe!', { queue: { exclusive: true } }, () => {}, {
+            meta: 'cyborg'
+        });
+
+        return carotte.invoke('hello-to-you-describe!:describe', {})
+            .then(({ data }) => {
+                expect(data.meta).to.be.defined;
+                expect(data.meta).to.be.eql('cyborg');
+            });
+    });
+});


### PR DESCRIPTION
New option for carotte: `autoDescribe`, default is false.

If auto describe is enabled, it will expose a `:describe` route for every subscriber (only if they have metas)