### PR TITLE
Add custom transport handling via config

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -15,9 +15,7 @@ function createDeferred(timeout) {
     return deferred;
 }
 
-function empty() {
-
-}
+function noop() {}
 
 function identity(x) {
     return () => x;
@@ -94,12 +92,12 @@ function serializeError(err) {
 }
 
 const emptyTransport = {
-    log: empty,
-    info: empty,
+    log: noop,
+    info: noop,
     // only disable error logs when tests are run
     // eslint-disable-next-line no-console
-    error: (!process.env.LOADED_MOCHA_OPTS) ? /* istanbul ignore next */ console.error : empty,
-    warn: empty
+    error: (!process.env.LOADED_MOCHA_OPTS) ? /* istanbul ignore next */ console.error : noop,
+    warn: noop
 };
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,6 +15,10 @@ function createDeferred(timeout) {
     return deferred;
 }
 
+function empty() {
+
+}
+
 function identity(x) {
     return () => x;
 }
@@ -89,6 +93,15 @@ function serializeError(err) {
     return extend(extractedError, err);
 }
 
+const emptyTransport = {
+    log: empty,
+    info: empty,
+    // only disable error logs when tests are run
+    // eslint-disable-next-line no-console
+    error: (!process.env.LOADED_MOCHA_OPTS) ? /* istanbul ignore next */ console.error : empty,
+    warn: empty
+};
+
 module.exports = {
     createDeferred,
     execInPromise,
@@ -96,5 +109,6 @@ module.exports = {
     serializeError,
     deserializeError,
     extend,
-    timedPromise
+    timedPromise,
+    emptyTransport
 };


### PR DESCRIPTION
Default behavior is to print only errors, except when running mocha
Fixes #18 