### PR TITLE
Always retry connect failure when error occurs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,7 @@ function Carotte(config) {
         enableDeadLetter: true,
         autoDescribe: false,
         retryOnError() {
-            return process.env.NODE_ENV === 'production';
+            return true;
         },
         transport: emptyTransport
     }, config);


### PR DESCRIPTION
When a disconnection occurs, it actually does not reconnect to broker when not in `NODE_ENV=production`. 

There is however an issue because the service does not crash and so the connection is never re-established.

This PR fixes it, by reconnecting always (default setting).