### PR TITLE
Change log level from .log to .info

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -254,7 +254,7 @@ function Carotte(config) {
 
                 return ok.then(() => {
                     producerDebug(`publishing to ${options.routingKey} on ${exchangeName}`);
-                    config.transport.log({
+                    config.transport.info({
                         context: options.context,
                         headers: options.headers,
                         data: payload,
@@ -454,7 +454,7 @@ function Carotte(config) {
                         headers['x-origin-consumer'] = qualifier;
                         context['origin-consumer'] = qualifier;
 
-                        config.transport.log({
+                        config.transport.info({
                             deliveryTag: message.fields.deliveryTag,
                             context,
                             headers,


### PR DESCRIPTION
Some loggers does not recognize `log` level, so we should use `info` level for every log that is not an `error` or a `warning`.