### PR TITLE
Don't use debugtoken for auto-generated queues names ('')

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -96,7 +96,7 @@ function serializeError(err) {
  * @return {string}         The queue name to use for your call
  */
 function getDebugQueueName(queue, options, tokenOverride) {
-    if (process.env.NODE_ENV === 'production') return queue;
+    if (process.env.NODE_ENV === 'production' || queue === '') return queue;
 
     // debug token can be extracted from config (env) or context
     const debugToken = tokenOverride || configs.debugToken;


### PR DESCRIPTION
RabbitMQ provides auto-generated queue names when the queue name is omitted. With debug tokens, it was replacing the empty queue name with `:debugToken`, skipping the auto-generation.