### PR TITLE
fix(carotte): also retry when subscribers throw non Error objects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -543,7 +543,11 @@ function Carotte(config) {
      */
     carotte.handleRetry =
     function handleRetry(qualifier, options, meta = {}, headers, context, message) {
-        return err => {
+        return error => {
+            const err = (error instanceof Error)
+                ? error
+                : new Error(error);
+
             // we MUST be on the same channel than the subscriber to ack a message
             // otherwise channel is borked =)
             return carotte.getChannel(qualifier, options.prefetch)

--- a/tests/client.js
+++ b/tests/client.js
@@ -1,5 +1,5 @@
 const defaults = {
-    host: process.env.AMQP_HOST
+    host: process.env.AMQP_HOST || 'localhost'
 };
 
 const builder = require('../src');


### PR DESCRIPTION
## [Context](https://github.com/cubyn/xxx/issues/414)
Carotte crashing when trying to retry with non Error objects
- [x] stop crashing

## Implementation details
Wrapping non Error objects.

## Content
- `new Error(err)`
- updated a case to test the behavior

## Remarks
- Also edited tests/client.js to use 'localhost' for rabbitmq server by default when env is not providing infos
