### PR TITLE
Fix RPC disconnects

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ function Carotte(config) {
                 initDebug(`channel ${channelKey} created correctly`);
                 chan.on('close', (err) => {
                     channels[channelKey] = undefined;
+                    replyToSubscription = undefined;
                     if (!isDebug) {
                         carotte.cleanExchangeCache();
                         carotte.onClose(err);
@@ -137,6 +138,7 @@ function Carotte(config) {
             })
             .catch(err => {
                 channels[channelKey] = undefined;
+                replyToSubscription = undefined;
                 if (!isDebug) {
                     carotte.cleanExchangeCache();
                     throw err;


### PR DESCRIPTION
## Description

I a channel gets disconnected thus killing the RPC queue, all further RPC calls would re-use that queue instead of creating a new one.

## Resolution

- [ ] Any channel error will now reset the RPC queue
- [ ] … making any subsequent RPC call recreate a fresh RPC queue