### PR TITLE
carotte.shutdown now awaits current messages + closes RMQ connection

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const amqp = require('amqplib');
 
 const autodocAgent = require('./autodoc-agent');
 const describe = require('./describe');
+const MessageRegister = require('./message-register');
 const carottePackage = require('../package');
 
 const { EXCHANGE_TYPE, EXCHANGES_AVAILABLE } = require('./constants');
@@ -68,6 +69,10 @@ function Carotte(config) {
 
     let exchangeCache = {};
     const correlationIdCache = {};
+
+    const consumers = [];
+    const messageRegister = new MessageRegister();
+    let shutdownPromise = null;
 
     let replyToSubscription;
     let connexion;
@@ -476,6 +481,8 @@ function Carotte(config) {
                     return chan.prefetch(options.prefetch)
                     .then(() => chan.consume(q.queue, message => {
                         consumerDebug(`message handled on ${exchangeName} by queue ${q.queue}`);
+                        messageRegister.start(qualifier);
+
                         const { headers } = message.properties;
 
                         const messageStr = message.content.toString();
@@ -493,7 +500,14 @@ function Carotte(config) {
 
                         if (message.fields.redelivered && !headers['x-ignore-redeliver']) {
                             return carotte.handleRetry(qualifier, options, meta,
-                                headers, context, message)(new Error('Unhandled message'));
+                                headers, context, message)(new Error('Unhandled message'))
+                                .then(result => {
+                                    messageRegister.finish(qualifier);
+                                    return result;
+                                }, error => {
+                                    messageRegister.finish(qualifier);
+                                    throw error;
+                                });
                         }
 
                         // execute the handler inside a try catch block
@@ -534,7 +548,14 @@ function Carotte(config) {
                             return chan.ack(message);
                         })
                         .catch(carotte.handleRetry(qualifier, options, meta,
-                            headers, context, message));
+                            headers, context, message))
+                        .then(result => {
+                            messageRegister.finish(qualifier);
+                            return result;
+                        }, error => {
+                            messageRegister.finish(qualifier);
+                            throw error;
+                        });
                     }))
                     .then(() => chan.prefetch(0))
                     .then(identity(q));
@@ -666,13 +687,62 @@ function Carotte(config) {
         return Promise.resolve();
     };
 
+    /**
+     * Gracefully shutdown carotte:
+     * 1. unsubscribe consumers from all channels
+     * 2. await current messages being processed
+     * 3. close RMQ connection
+
+     * @param  {Number} timeout
+     *         if 0 no timeout when awaiting current messages
+     *         (risks of process hanging if consumer won't resolve)
+     * @return {Promise<Array<String>, Error>}
+     *         if success - returns an array of qualifiers
+     *             having been succesfully awaited
+     *         if error - rejects MessageWaitTimeoutError
+     *             containing messages that have timed out
+     */
+    carotte.shutdown = function shutdown(timeout = 0) {
+        if (shutdownPromise) return shutdownPromise;
+
+        // unsubscribe for any new message
+        const unsubscribeAll = consumers.map(
+            consumer => consumer.chan.cancel(consumer.consumerTag)
+        );
+
+        let awaitError;
+        let awaitedMessages;
+
+        shutdownPromise =
+            // unsubscribe from all queues
+            Promise.all(unsubscribeAll)
+            // wait for current messages to be acked or nacked
+            .then(() => messageRegister.wait(timeout))
+            .then(messages => (awaitedMessages = messages))
+            // in case we could not wait for all messages,
+            // we still need to go on closing RMQ connection
+            .catch(error => (awaitError = error))
+            // finally close RMQ TCP connection
+            .then(() => connexion)
+            .then(c => c.close())
+            .then(() => {
+                if (awaitError) throw awaitError;
+                return awaitedMessages;
+            });
+
+        return shutdownPromise;
+    };
+
     if (config.enableAutodoc) {
         autodocAgent.ensureAutodocAgent(carotte);
     }
 
-    function logError(err) {
-        config.transport.error(err);
-        return err;
+    function logError(error) {
+        // when close is initiated by .close(), amqplib
+        // emits 'close' without any error
+        if (error) config.transport.error(error);
+
+        return error;
     }
 
     carotte.onError = logError;

--- a/src/message-register.js
+++ b/src/message-register.js
@@ -1,0 +1,83 @@
+/**
+ * A simple tool to register message starts & finishes
+ * and wait for all messages to be finished
+ */
+
+class MessageWaitTimeoutError extends Error {
+    constructor(awaitedMessages, timeoutedMessages, timeout) {
+        super(`Timeout while waiting for ${timeoutedMessages.length} to finish`);
+        this.awaitedMessages = awaitedMessages;
+        this.timeoutedMessages = timeoutedMessages;
+        this.timeout = timeout;
+    }
+}
+
+module.exports = class MessageRegister {
+    constructor() {
+        this.currentMessages = [];
+        this.waitResolve = null;
+    }
+
+    /**
+     * get current total of messages being consumed
+     * @return {Number}
+     */
+    total() {
+        return this.currentMessages.length;
+    }
+
+    /**
+     * register message consumption start
+     * @param  {String} qualifier
+     */
+    start(qualifier) {
+        this.currentMessages.push(qualifier);
+    }
+
+    /**
+     * register message consumption finish
+     * @param  {String} qualifier
+     */
+    finish(qualifier) {
+        const index = this.currentMessages.indexOf(qualifier);
+        this.currentMessages.splice(index, 1);
+
+        if (this.waitResolve && !this.total()) {
+            this.waitResolve();
+            this.waitResolve = null;
+        }
+    }
+
+    /**
+     * Wait for all current messages to be finished with
+     * optional timeout
+     *
+     * @param  {Number} timeout disabled when 0
+     * @return {Promise<Array<String>, MessageWaitTimeoutError>}
+     *         On success: resolved with messages awaited
+     *         On error: rejected with MessageWaitTimeoutError
+     */
+    wait(timeout = 0) {
+        return new Promise((resolve, reject) => {
+            if (this.total() === 0) {
+                resolve([]);
+                return;
+            }
+
+            // make a copy of current messages to be awaited
+            const awaitedMessages = this.currentMessages.slice(0);
+
+            const timeoutId = timeout && setTimeout(
+                () => reject(new MessageWaitTimeoutError(
+                    awaitedMessages, this.currentMessages, timeout
+                )),
+                timeout
+            );
+
+            this.waitResolve = () => {
+                resolve(awaitedMessages);
+                timeoutId && clearTimeout(timeoutId);
+            };
+        });
+    }
+};


### PR DESCRIPTION
1. unsubscribe consumers from all channels
2. await current messages being processed
3. close RMQ connection