### PR TITLE
From "onClose" to "onChannelClose" and "onConnectionClose"

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ function Carotte(config) {
                 connexion = undefined;
                 channels = {};
                 carotte.cleanExchangeCache();
-                carotte.onClose(err);
+                carotte.onConnectionClose(err);
             });
             conn.once('error', carotte.onError);
 
@@ -128,7 +128,7 @@ function Carotte(config) {
                     replyToSubscription = undefined;
                     if (!isDebug) {
                         carotte.cleanExchangeCache();
-                        carotte.onClose(err);
+                        carotte.onChannelClose(err);
                     }
                 });
 
@@ -750,7 +750,8 @@ function Carotte(config) {
     }
 
     carotte.onError = logError;
-    carotte.onClose = logError;
+    carotte.onChannelClose = logError;
+    carotte.onConnectionClose = logError;
 
     return carotte;
 }


### PR DESCRIPTION
Exposing only `onClose` callback only leads to the loss of details on what's going on AMQP.

From:

```js
// channel and/or connection closed
carotte.onClose(() => {
  // graceful shutdown
});
```

To:

```js
// channel closed
// may not be used if `onConnectionClose` callback is already implemented
carotte.onChannelClose(() => {
  // graceful shutdown
});

// connection closed
carotte.onConnectionClose(() => {
  // graceful shutdown
});
```