### PR TITLE
[OR-45] feat: request in error log

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -604,6 +604,7 @@ function Carotte(config) {
                     headers,
                     subscriber: qualifier,
                     destination: '',
+                    request: JSON.parse(message.content).data,
                     error: err
                 });
 


### PR DESCRIPTION
|   Status   |         Type          |        Ticket         |
| :--------: | :-------------------: | :-------------------: |
| Ready | Feature | [OR-45](https://cubynjira.atlassian.net/browse/OR-45) |

## Problem

We have already included the request payload in successful response logs #124, but we do not yet include it when the execution threw an error.

## Solution

Add a `request` property in error log with the request payload.
