### PR TITLE
Fix/durable queue and persistent messages

### DIFF
--- a/src/describe.js
+++ b/src/describe.js
@@ -16,7 +16,11 @@ module.exports.subscribeToDescribe = function (carotte, qualifier, meta) {
         qualifier = qualifier.replace(`:${configs.debugToken}`, '');
     }
 
-    carotte.subscribe(`${qualifier}:describe`, { queue: { durable: false, autoDelete: true } }, () => {
+    /**
+     * Previous :describe queues were set with `durable: false` which was causing issues.
+     * Since queue properties are immutable, metas are now exposed on :describe:v2 queues.
+     */
+    carotte.subscribe(`${qualifier}:describe:v2`, { queue: { durable: true, autoDelete: true } }, () => {
         return meta;
     });
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import { Connection, Channel } from 'amqplib';
+import { Connection, Channel, Options } from 'amqplib';
 
 declare namespace CarotteAmqp {
     interface Logger {
@@ -26,6 +26,17 @@ declare namespace CarotteAmqp {
                 'carotte-host-version': string;
             };
         };
+    };
+
+    type PublishOptions = Pick<Options.Publish,  'persistent'> & {
+        exchangeName?: string;
+        context?: object;
+        headers?: Options.Publish['headers'] & {
+            'x-reply-to'?: string;
+        },
+        log?: boolean;
+        durable?: boolean;
+        isContentBuffer?: boolean;
     };
 
     type SubscribeMeta = {
@@ -99,7 +110,7 @@ declare namespace CarotteAmqp {
          * @param {object} [payload] - Data to send to the function
          * @return {promise} return when message is published
          */
-        publish<Payload = any, Response = any, Options = object>(qualifier: string, options: Options, payload: Payload): Promise<Response>;
+        publish<Payload = any, Response = any, Options extends PublishOptions = object>(qualifier: string, options: Options, payload: Payload): Promise<Response>;
 
         /**
          * Invoke a function
@@ -116,7 +127,7 @@ declare namespace CarotteAmqp {
          * @param {object} payload - Data to send to the function
          * @return {promise} return the function response
          */
-        invoke<Payload = any, Response = any, Options = object>(qualifier: string, options: Options, payload: Payload): Promise<Response>;
+        invoke<Payload = any, Response = any, Options extends PublishOptions = object>(qualifier: string, options: Options, payload: Payload): Promise<Response>;
 
         /**
          * Invoke a function and expect a result

--- a/tests/dead-letter.spec.js
+++ b/tests/dead-letter.spec.js
@@ -22,11 +22,12 @@ describe('dead-letter', () => {
         .then(() => {
             throw new Error('should not reach here');
         }, err => {
-            // check that the deadletter queue received the right error
-            expect(deadletterError.message).to.eql(ERROR_MESSAGE);
-
             // check that the consumer RPC queue received the right error
             expect(err.message).to.eql(ERROR_MESSAGE);
+
+            expect(deadletterError).not.to.be.undefined;
+            // check that the deadletter queue received the right error
+            expect(deadletterError.message).to.eql(ERROR_MESSAGE);
         });
     });
 });

--- a/tests/describe.spec.js
+++ b/tests/describe.spec.js
@@ -4,30 +4,29 @@ const carotte = require('./client')({
 });
 
 describe('describe', () => {
-    it('should expose metas on a direct route using a :describe suffix', () => {
+    it('should expose metas on a direct route using a :describe:v2 suffix', () => {
         carotte.subscribe('hello-to-you-describe!', { queue: { exclusive: true } }, () => {}, {
             meta: 'cyborg'
         });
 
-        return carotte.invoke('hello-to-you-describe!:describe', {})
+        return carotte.invoke('hello-to-you-describe!:describe:v2', {})
             .then(data => {
                 expect(data.meta).to.be.a('string');
                 expect(data.meta).to.eql('cyborg');
             });
     });
 
-    it('should expose metas on a topic route using a :describe suffix on a direct route', (done) => {
+    it('should expose metas on a topic route using a :describe:v2 suffix on a direct route', () => {
         carotte.subscribe('topic/hello-to-you-describe!', { queue: { exclusive: true } }, () => {
-            done(new Error('Das is not gut!'));
+            throw new Error('Das is not gut!');
         }, {
             meta: 'cyborg'
         });
 
-        carotte.invoke('hello-to-you-describe!:describe', {})
+        return carotte.invoke('hello-to-you-describe!:describe:v2', {})
             .then(data => {
                 expect(data.meta).to.be.a('string');
                 expect(data.meta).to.be.eql('cyborg');
-            })
-            .then(done);
+            });
     });
 });


### PR DESCRIPTION
# Description

## Context

https://cubyn.slack.com/archives/CJVNYTQLT/p1651139559755859

Timeout when asserting queues pointing at missing nodes causing downtime.

## Solution

- make describe queue `durable` (e.g. will not be destroyed when cluster restart)
- post `persistent` message (e.g. messages are stored and will be recovered on a restart)

## Related

[Jira](https://cubynjira.atlassian.net/browse/SUP-1497)