### PR TITLE
fix: ensure multiple checks for queue existence are performed sequent…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/amqplib": "^0.5.13",
     "amqplib": "^0.5.3",
     "debug": "^2.6.0",
+    "p-limit": "2.3.0",
     "puid": "^1.0.5",
     "safe-clone-deep": "^1.1.5"
   },

--- a/tests/client.js
+++ b/tests/client.js
@@ -4,6 +4,10 @@ const defaults = {
 
 const builder = require('../src');
 
+/**
+ * @param {builder.CarotteAmqp.CarotteOptions} [options]
+ * @returns {builder.CarotteAmqp.Transport}
+ */
 module.exports = function (options) {
     return builder(Object.assign({}, defaults, options));
 };

--- a/tests/publisher.spec.js
+++ b/tests/publisher.spec.js
@@ -1,7 +1,15 @@
 const expect = require('chai').expect;
+const sinon = require('sinon');
+const amqplibChannel = require('amqplib/lib/channel_model');
 const carotte = require('./client');
 
+const sandbox = sinon.createSandbox();
+
 describe('publisher', () => {
+    afterEach(() => {
+        sandbox.restore();
+    });
+
     it('should return a promise', () => {
         const returnValue = carotte().publish('', {});
         expect(returnValue).to.be.a('promise');
@@ -33,5 +41,55 @@ describe('publisher', () => {
             .catch(err => {
                 expect(err.message).not.to.be.eql('Should not pass');
             });
+    });
+
+    it('should add debug token if available', async () => {
+        const channelPublishSpy = sandbox.spy(amqplibChannel.Channel.prototype, 'publish');
+        const client = carotte();
+
+        const qualifier = 'some.qualifier:v1:describe';
+        const qualifierV2 = `${qualifier}:v2`;
+        const debugToken = 'debug-test-12';
+        const spy = sinon.spy();
+        await client.subscribe(`${qualifierV2}:${debugToken}`, () => {
+            spy();
+        });
+
+        const options = {
+            context: {
+                debugToken
+            }
+        };
+        /**
+         * first call will reject and cause channel destruction
+         */
+        await Promise.race([qualifier, qualifierV2]
+            .map(queue => client.invoke(queue, options, {}))
+        );
+
+        sinon.assert.calledOnce(spy);
+        sinon.assert.calledThrice(channelPublishSpy);
+        sinon.assert.calledWithExactly(
+            channelPublishSpy.firstCall,
+            'amq.direct',
+            'some.qualifier:v1:describe',
+            sinon.match.any,
+            sinon.match.any
+        );
+        sinon.assert.calledWithExactly(
+            channelPublishSpy.secondCall,
+            'amq.direct',
+            'some.qualifier:v1:describe:v2:debug-test-12',
+            sinon.match.any,
+            sinon.match.any
+        );
+        /** rpc answer */
+        sinon.assert.calledWithExactly(
+            channelPublishSpy.thirdCall,
+            'amq.direct',
+            sinon.match.string,
+            sinon.match.any,
+            sinon.match.any
+        );
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,6 +1503,13 @@ os-homedir@^1.0.0:
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
   integrity sha1-/7xJiDNuDoM94MFox+8VISGqf7M=
 
+p-limit@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
+  integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+  dependencies:
+    p-try "^2.0.0"
+
 p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
@@ -1521,6 +1528,11 @@ p-try@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
   integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
…ially

# Description

## Context

While testing multiple calls in parallel with potentially missing queues, we discovered some issues when checking queue as this `checkQueue` will close the used channel.

## Related

[Jira](https://cubynjira.atlassian.net/browse/SUP-1497)
Has been revealed by [Github](https://github.com/cubyn/node-carotte-amqp/pull/130)