### PR TITLE
Revert "feat: create durable `describe:v2` queues to replace `describ…

### DIFF
--- a/src/describe.js
+++ b/src/describe.js
@@ -16,11 +16,7 @@ module.exports.subscribeToDescribe = function (carotte, qualifier, meta) {
         qualifier = qualifier.replace(`:${configs.debugToken}`, '');
     }
 
-    /**
-     * Previous :describe queues were set with `durable: false` which was causing issues.
-     * Since queue properties are immutable, metas are now exposed on :describe:v2 queues.
-     */
-    carotte.subscribe(`${qualifier}:describe:v2`, { queue: { durable: true, autoDelete: true } }, () => {
+    carotte.subscribe(`${qualifier}:describe`, { queue: { durable: false, autoDelete: true } }, () => {
         return meta;
     });
 };

--- a/tests/describe.spec.js
+++ b/tests/describe.spec.js
@@ -4,29 +4,30 @@ const carotte = require('./client')({
 });
 
 describe('describe', () => {
-    it('should expose metas on a direct route using a :describe:v2 suffix', () => {
+    it('should expose metas on a direct route using a :describe suffix', () => {
         carotte.subscribe('hello-to-you-describe!', { queue: { exclusive: true } }, () => {}, {
             meta: 'cyborg'
         });
 
-        return carotte.invoke('hello-to-you-describe!:describe:v2', {})
+        return carotte.invoke('hello-to-you-describe!:describe', {})
             .then(data => {
                 expect(data.meta).to.be.a('string');
                 expect(data.meta).to.eql('cyborg');
             });
     });
 
-    it('should expose metas on a topic route using a :describe:v2 suffix on a direct route', () => {
+    it('should expose metas on a topic route using a :describe suffix on a direct route', (done) => {
         carotte.subscribe('topic/hello-to-you-describe!', { queue: { exclusive: true } }, () => {
-            throw new Error('Das is not gut!');
+            done(new Error('Das is not gut!'));
         }, {
             meta: 'cyborg'
         });
 
-        return carotte.invoke('hello-to-you-describe!:describe:v2', {})
+        carotte.invoke('hello-to-you-describe!:describe', {})
             .then(data => {
                 expect(data.meta).to.be.a('string');
                 expect(data.meta).to.be.eql('cyborg');
-            });
+            })
+            .then(done);
     });
 });


### PR DESCRIPTION
…e` ones"

This reverts commit df6835760392dbb76356d495d7be67413734d12a.