### PR TITLE
feat: observability on RPC queues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -480,6 +480,10 @@ function Carotte(config) {
             // create the queue for this exchange.
             .then(() => chan.assertQueue(queueName, options.queue))
             .then(q => {
+                if (qualifier === '') {
+                    config.transport.info('carotte-amqp: subscribed to rpc queue', { queue: q });
+                }
+
                 consumerDebug(`queue ${q.queue} ready.`);
                 // bind the newly created queue to the chan
 

--- a/src/index.js
+++ b/src/index.js
@@ -783,17 +783,17 @@ function Carotte(config) {
         autodocAgent.ensureAutodocAgent(carotte);
     }
 
-    function logError(error) {
+    function logError(message, error) {
         // when close is initiated by .close(), amqplib
         // emits 'close' without any error
-        if (error) config.transport.error('carotte-amqp: error caught', { error });
+        if (error) config.transport.error(`carotte-amqp: ${message}`, { error });
 
         return error;
     }
 
-    carotte.onError = logError;
-    carotte.onChannelClose = logError;
-    carotte.onConnectionClose = logError;
+    carotte.onError = error => logError('error caught', error);
+    carotte.onChannelClose = error => logError('channel closed', error);
+    carotte.onConnectionClose = error => logError('connection closed', error);
 
     return carotte;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -132,6 +132,8 @@ function Carotte(config) {
             .then(chan => {
                 initDebug(`channel ${channelKey} created correctly`);
                 chan.on('close', (err) => {
+                    config.transport.info('carotte-amqp: channel closed', { channelKey });
+
                     channels[channelKey] = undefined;
                     replyToSubscription = undefined;
                     if (!isDebug) {
@@ -770,7 +772,7 @@ function Carotte(config) {
     function logError(error) {
         // when close is initiated by .close(), amqplib
         // emits 'close' without any error
-        if (error) config.transport.error(error);
+        if (error) config.transport.error('carotte-amqp: error caught', { error });
 
         return error;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -588,6 +588,16 @@ function Carotte(config) {
                     .then(() => chan.prefetch(0))
                     .then(identity(q));
                 });
+            })
+            .catch(error => {
+                config.transport.error('carotte-amqp: failed to subscribe queue', {
+                    error,
+                    qualifier,
+                    options,
+                    meta
+                });
+
+                throw error;
             });
     };
 


### PR DESCRIPTION
- feat: improve logs when channel closes
- fix: do not try closing connexion again
- feat: log when subscribed to rpc queue
- feat: log in case of error while subscribing
- fix: explicit message when logging error

I want to release this as beta, deploy it on service-storage-inbound-order, and run again to see the logs: good for you?