### PR TITLE
Fix/sup 1595/no rpc close

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -23,6 +23,10 @@ function createDeferred(timeout) {
 
 function noop() {}
 
+/**
+ * @template I
+ * @param {I} x
+ */
 function identity(x) {
     return () => x;
 }


### PR DESCRIPTION
# Context

We observed an increasing amount of queues in staging

# Cause

Every time an invoke/publish was performed with a debug token but the queue does not exist, the used channel was closed.
Whenever we close a channel, the replyToSubscription was cleaned up resulting in a new RPC queue created.

# Remarks

Added a test to confirm this case

`rpc parallel` suite is not correctly tested as creating a new carotte client for each test causes the following error for the test `should be able to clear a parallel execution`

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/8013026/173081339-8c5f2743-d3be-45c7-943d-3a6dcf5f7227.png">
