### PR TITLE
fix: subscription timeout

### DIFF
--- a/src/configs.js
+++ b/src/configs.js
@@ -60,7 +60,9 @@ function parseSubscriptionOptions(options, qualifier) {
         routingKey: '',
         durable: true,
         queue: {},
-        exchange: {}
+        exchange: {},
+        // 1 minute
+        subscriptionTimeout: 60000
     }, options, parseQualifier(qualifier));
 
     options.queue = Object.assign({

--- a/tests/subscriber.spec.js
+++ b/tests/subscriber.spec.js
@@ -202,4 +202,18 @@ describe('subscriber', () => {
             });
         });
     });
+
+    describe('when subscribing to the queue takes more time than the configured timeout', () => {
+        it('times out', () => {
+            return carotte.subscribe('configured-timeout-is-too-short', { subscriptionTimeout: 1 }, () => {})
+                .then(
+                    () => {
+                        throw new Error('subscribe must reject');
+                    },
+                    (error) => {
+                        expect(error.message).to.eql('carotte subscription timeout');
+                    }
+                );
+        });
+    });
 });


### PR DESCRIPTION
## Problem

We've seen during some RabbitMQ maintenance that for some queues, the binding step can hang forever. It seems this happens when RabbitMQ reaches a corrupt state where the queue is still  eferenced in its internal database, but references a node that doesn't exist anymore.

When that happened, it led to situations where the service was consuming messages only of some queues. In particular, we faced a situation where the "listener" queues of a given service were gone, such that some topics were never processed by the service, creating major data inconsistencies and leading to one of the worst business days at Cubyn in years.

It also led to describe queues to not have any consumer, such that gateway rest wasn't discovering the controllers. It made some endpoints unavailable, but at least it wasn't creating a false sense that the feature was working.

## Solution

We don't know how to reproduce that issue, but we know that solving it was easy as forcing all pods to restart again (= rollout restart). Enforcing a timeout on the subscription will effectively create the same behavior, allowing the service to auto-repair itself.
