### PR TITLE
fix: trigger restart when consumer cancelled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -592,7 +592,9 @@ function Carotte(config) {
                         subscriber: assertQueue.queue,
                         exchangeName
                     });
-                    return Promise.resolve();
+
+                    // we throw an error to trigger a restart of the service
+                    throw new Error('carotte consumer cancelled');
                 }
 
                 consumerDebug(`message handled on ${exchangeName} by queue ${assertQueue.queue}`);


### PR DESCRIPTION
## Problem

We had an issue on July 1st 2022 where some listener queues had disappeared following a RabbitMQ maintenance. The list correlates entirely with [these logs](https://app.datadoghq.com/logs?query=carotte-amqp%20consumer%20cancelled%20by%20rabbitmq%20%20%40env%3Aproduction&cols=service%2C%40subscriber&index=&messageDisplay=inline&stream_sort=time%2Cdesc&viz=stream&from_ts=1599748809000&to_ts=1600958409000&live=true).

Before [this commit](https://github.com/cubyn/node-carotte-amqp/commit/0a54562d9a8b3e1a1a97a0e985ab3ed931d5b1ee), the behavior would be to trigger a `TypeError: Cannot read property 'properties' of null` at [this line](https://github.com/cubyn/node-carotte-amqp/blob/dbb3e7fb97bf0e85cc1021f2339835c583a6c4b1/src/index.js#L603), which would trigger the `onError` handlers of `carotte-loader` / `carotte-runtime`, ultimately causing the service to restart.

## Solution

Throw an error instead of silently ignoring, to trigger a restart of the service.
