### PR TITLE
feat: await for describe queue subscription when subscribing to queues

### DIFF
--- a/src/describe.js
+++ b/src/describe.js
@@ -16,7 +16,7 @@ module.exports.subscribeToDescribe = function (carotte, qualifier, meta) {
         qualifier = qualifier.replace(`:${configs.debugToken}`, '');
     }
 
-    carotte.subscribe(`${qualifier}:describe`, { queue: { durable: false, autoDelete: true } }, () => {
+    return carotte.subscribe(`${qualifier}:describe`, { queue: { durable: false, autoDelete: true } }, () => {
         return meta;
     });
 };

--- a/src/index.js
+++ b/src/index.js
@@ -462,10 +462,11 @@ function Carotte(config) {
             qualifier = getDebugQueueName(qualifier, options);
         }
 
+        const promises = [];
         if (meta) {
             autodocAgent.addSubscriber(qualifier, meta);
             if (config.autoDescribe) {
-                describe.subscribeToDescribe(this, qualifier, meta);
+                promises.push(describe.subscribeToDescribe(this, qualifier, meta));
             }
         }
 
@@ -474,7 +475,7 @@ function Carotte(config) {
         const exchangeName = getExchangeName(options);
         const queueName = getQueueName(options, config);
 
-        return Promise.race([
+        return Promise.race(promises.concat([
             new Promise((_resolve, reject) => {
                 setTimeout(() => {
                     /**
@@ -534,7 +535,7 @@ function Carotte(config) {
 
                     throw error;
                 })
-        ]);
+        ]));
 
 
         /**


### PR DESCRIPTION
## Context

Masterbag inbound process failing sometimes.
https://cubyn.slack.com/archives/C3US319PA/p1661962354346349
TL;DR inbound was correctly done but missing describe queue was raising an error when refreshing the list of in transit masterbags.

## Description

Queue with meta without any describe queue will most likely lead to timeout when calling {qualifier}:describe hence I think we should wait for its subscription as well.