### PR TITLE
Fix subscription open handle & shutdown

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -474,9 +474,11 @@ function Carotte(config) {
         const exchangeName = getExchangeName(options);
         const queueName = getQueueName(options, config);
 
+        let subscriptionTimeout = null;
+
         return Promise.race([
             new Promise((_resolve, reject) => {
-                setTimeout(() => {
+                subscriptionTimeout = setTimeout(() => {
                     /**
                      * We've seen during some RabbitMQ maintenance that for some queues, the binding
                      * step can hang forever. It seems this happens when RabbitMQ reaches a corrupt
@@ -534,6 +536,7 @@ function Carotte(config) {
 
                     throw error;
                 })
+                .finally(() => clearTimeout(subscriptionTimeout))
         ]);
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -875,7 +875,9 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
             })
             // finally close RMQ TCP connection
             .then(() => connexion)
-            .then(c => c.close())
+            .then((c) => {
+                if (c) c.close();
+            })
             .then(() => {
                 if (awaitError) throw awaitError;
                 return awaitedMessages;

--- a/tests/rpc.spec.js
+++ b/tests/rpc.spec.js
@@ -12,6 +12,32 @@ describe('rpc', () => {
         sandbox.restore();
     });
 
+    describe('shutdown', () => {
+        beforeEach(() => {
+            carotte = carotteFactory();
+        });
+
+        describe('when connection has been initialized', () => {
+            it('shutdowns the client', () => {
+                return carotte
+            .subscribe(
+              'fanout/abcdef',
+              { exchangeName: 'test2', queue: { exclusive: true } },
+              ({ data }) => data
+            )
+            .then(() => {
+                return carotte.shutdown();
+            });
+            }).timeout(5000);
+        });
+
+        describe('when connection has NOT been initialized', () => {
+            it('shutdowns the client', () => {
+                return carotte.shutdown();
+            }).timeout(5000);
+        });
+    });
+
     describe('invoke', () => {
         beforeEach(() => {
             carotte = carotteFactory();


### PR DESCRIPTION
### Open handle

Currently, using carotte-amqp `invoke` function from a jest test create an open handle error because of the timeout promise (default value 1 minute).

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

      ...

      at ../../node_modules/carotte-amqp/src/index.js:479:17
      at Object.subscribe (../../node_modules/carotte-amqp/src/index.js:478:13)
      at Object.getRpcQueue (../../node_modules/carotte-amqp/src/index.js:187:43)
      at Object.invoke (../../node_modules/carotte-amqp/src/index.js:366:17)
      ...
```

### Shutdown on non-initialized connection

Currently, we cannot shutdown a client if the connection has not been initialized

```
  ● Test suite failed to run

    TypeError: Cannot read properties of undefined (reading 'close')

      ...

      at ../../node_modules/carotte-amqp/src/index.js:875:26
      ...
```