### PR TITLE
Provide an option to disable the logger on subscriber

### DIFF
--- a/src/configs.js
+++ b/src/configs.js
@@ -1,5 +1,6 @@
 const { join } = require('path');
 const { EXCHANGE_TYPE, EXCHANGES_AVAILABLE } = require('./constants');
+const { emptyTransport } = require('./utils');
 
 function parseQualifier(qualifier) {
     let [
@@ -55,7 +56,7 @@ function getQueueName(options, config) {
     return '';
 }
 
-function parseSubscriptionOptions(options, qualifier) {
+function parseSubscriptionOptions(options, qualifier, config) {
     options = Object.assign({
         routingKey: '',
         durable: true,
@@ -77,6 +78,10 @@ function parseSubscriptionOptions(options, qualifier) {
     options.exchange = Object.assign({
         durable: true
     }, options.exchange);
+
+    options.transport = options.transport === null
+        ? emptyTransport
+        : (options.transport || config.transport);
 
     return options;
 }

--- a/src/configs.js
+++ b/src/configs.js
@@ -62,7 +62,11 @@ function parseSubscriptionOptions(options, qualifier) {
         queue: {},
         exchange: {},
         // 1 minute
-        subscriptionTimeout: 60000
+        subscriptionTimeout: 60000,
+        // undefined means root transport, from config
+        // null means no transport
+        // otherwise, override
+        transport: undefined
     }, options, parseQualifier(qualifier));
 
     options.queue = Object.assign({

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,6 +1,5 @@
 const { join } = require('path');
 const { EXCHANGE_TYPE, EXCHANGES_AVAILABLE } = require('./constants');
-const { emptyTransport } = require('./utils');
 
 function parseQualifier(qualifier) {
     let [
@@ -80,7 +79,12 @@ function parseSubscriptionOptions(options, qualifier, config) {
     }, options.exchange);
 
     options.transport = options.transport === null
-        ? emptyTransport
+        ? {
+            log: () => {},
+            info: () => {},
+            error: () => {},
+            warn: () => {}
+        }
         : (options.transport || config.transport);
 
     return options;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,6 +66,14 @@ declare namespace CarotteAmqp {
             durable: boolean;
         };
         prefetch?: number;
+        /**
+         * Override or deactivate the root transport for this subscriber ONLY.
+         * 
+         * undefined means the root transport (from config) will be used
+         * null means transport will be deactivated
+         * otherwise the value will be used as transport
+         */
+        transport?: Logger | null;
     };
 
     type SubscribeHandlerParameter = {

--- a/src/index.js
+++ b/src/index.js
@@ -469,11 +469,8 @@ function Carotte(config) {
             }
         }
 
-        options = parseSubscriptionOptions(options, qualifier);
+        options = parseSubscriptionOptions(options, qualifier, config);
 
-        const transport = options.transport === null
-            ? emptyTransport
-            : (options.transport || config.transport);
         const exchangeName = getExchangeName(options);
         const queueName = getQueueName(options, config);
 
@@ -670,7 +667,7 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                     consumerDebug('Handler success');
                     // otherwise internal subscribe (rpc…)
                     if (qualifier) {
-                        transport.info(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
+                        options.transport.info(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
                             context,
                             headers,
                             response,

--- a/src/index.js
+++ b/src/index.js
@@ -729,7 +729,7 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                 const pubOptions = messageToOptions(qualifier, message);
                 const rpc = headers['x-reply-to'] !== undefined;
 
-                config.transport.error(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
+                options.transport.error(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
                     context,
                     headers,
                     subscriber: qualifier,

--- a/src/index.js
+++ b/src/index.js
@@ -471,6 +471,9 @@ function Carotte(config) {
 
         options = parseSubscriptionOptions(options, qualifier);
 
+        const transport = options.transport === null
+            ? emptyTransport
+            : (options.transport || config.transport);
         const exchangeName = getExchangeName(options);
         const queueName = getQueueName(options, config);
 
@@ -667,7 +670,7 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                     consumerDebug('Handler success');
                     // otherwise internal subscribe (rpc…)
                     if (qualifier) {
-                        config.transport.info(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
+                        transport.info(`${rpc ? '◀ ' : '◁ '} ${qualifier}`, {
                             context,
                             headers,
                             response,


### PR DESCRIPTION
## Issue

Currently, domain-events from warehouse services are pushed through Rabbit via a single queue (.e.g `topic/service-wms@${MODULE}.domain-events-batch.published:v1`). Most listeners listen for specific domain event types and ignore calls that do not include their types. This produces a large number of ignored execution logs.  
We want to leave it up to the listener to decide whether or not to log the event.

## Solution

Give the availability to the parent to disable the default logger on some subscribers. It allows warehouse services to disable the logger on domain-events subscribers.

## Note

I used the `transport` option key to stay compliant with the config key which is `transport` too.
