### PR TITLE
obs: payload size

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,6 +296,7 @@ function Carotte(config) {
                                     context: options.context,
                                     headers: options.headers,
                                     request: getRequestPayload(payload, options),
+                                    requestSize: buffer.length,
                                     subscriber: options.context['origin-consumer'] || '',
                                     destination: qualifier
                                 });
@@ -321,6 +322,7 @@ function Carotte(config) {
                             context: options.context,
                             headers: options.headers,
                             request: payload,
+                            requestSize: buffer.length,
                             subscriber: options.context['origin-consumer'] || '',
                             destination: qualifier,
                             error: err
@@ -663,7 +665,9 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                             context,
                             headers,
                             response,
+                            responseSize: getBufferPayload(response, { context }).length,
                             request: data,
+                            requestSize: message.content.length,
                             subscriber: qualifier,
                             destination: '',
                             executionMs: new Date().getTime() - startTime,
@@ -727,8 +731,10 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                     subscriber: qualifier,
                     destination: '',
                     request: JSON.parse(message.content).data,
+                    requestSize: message.content.length,
                     executionMs: startTime ? new Date().getTime() - startTime : null,
-                    error: err
+                    error: err,
+                    errorSize: Buffer.from(JSON.stringify(serializeError(err))).length
                 });
 
                 // if custom error thrown, we want to forward it to producer

--- a/src/index.js
+++ b/src/index.js
@@ -269,15 +269,7 @@ function Carotte(config) {
                     persistent = true
                 } = options;
 
-                // isContentBuffer is used by internal functions who don't modify the content
-                const buffer = options.isContentBuffer
-                    ? payload
-                    : Buffer.from(JSON.stringify({
-                        data: payload,
-                        context: Object.assign({}, options.context, {
-                            transactionStack: getTransactionStack(options.context)
-                        })
-                    }));
+                const buffer = getBufferPayload(payload, options);
 
                 producerDebug('called');
 
@@ -988,7 +980,11 @@ function getContext(message) {
     }
 }
 
-
+/**
+ *
+ * @param {Buffer} payload
+ * @param {*} options
+ */
 function getRequestPayload(payload, options) {
     if (!options.isContentBuffer) {
         return payload;
@@ -1005,6 +1001,26 @@ function getRequestPayload(payload, options) {
     } catch (error) {
         return payload;
     }
+}
+
+/**
+ *
+ * @param {*} payload
+ * @param {{ isContentBuffer?: boolean; context: any }} options
+ * @returns {Buffer}
+ */
+function getBufferPayload(payload, options) {
+    // isContentBuffer is used by internal functions who don't modify the content
+    if (options.isContentBuffer) {
+        return payload;
+    }
+
+    return Buffer.from(JSON.stringify({
+        data: payload,
+        context: Object.assign({}, options.context, {
+            transactionStack: getTransactionStack(options.context)
+        })
+    }));
 }
 
 /**

--- a/tests/transport.spec.js
+++ b/tests/transport.spec.js
@@ -87,7 +87,8 @@ describe('transport info', () => {
                 request: sinon.match({ query: 'hello' }),
                 requestSize: 66,
                 error: sinon.match({ status: 500, name: 'CustomError' }),
-                errorSize: 1543,
+                // exact size depends on the stack trace
+                errorSize: sinon.match.number,
                 executionMs: sinon.match.number
             })
         );

--- a/tests/transport.spec.js
+++ b/tests/transport.spec.js
@@ -29,7 +29,8 @@ describe('transport info', () => {
             '▶  direct/hello-transport',
             sinon.match({
                 destination: 'hello-transport',
-                request: sinon.match({ query: 'hello-transport' })
+                request: sinon.match({ query: 'hello-transport' }),
+                requestSize: 76
             })
         );
 
@@ -38,7 +39,9 @@ describe('transport info', () => {
             sinon.match({
                 subscriber: 'hello-transport',
                 request: sinon.match({ query: 'hello-transport' }),
+                requestSize: 76,
                 response: sinon.match({ result: 'hello-back' }),
+                responseSize: 79,
                 executionMs: sinon.match.number
             })
         );
@@ -72,7 +75,8 @@ describe('transport info', () => {
             '▶  direct/throw-transport',
             sinon.match({
                 destination: 'throw-transport',
-                request: sinon.match({ query: 'hello' })
+                request: sinon.match({ query: 'hello' }),
+                requestSize: 66
             })
         );
 
@@ -81,7 +85,9 @@ describe('transport info', () => {
             sinon.match({
                 subscriber: 'throw-transport',
                 request: sinon.match({ query: 'hello' }),
+                requestSize: 66,
                 error: sinon.match({ status: 500, name: 'CustomError' }),
+                errorSize: 1543,
                 executionMs: sinon.match.number
             })
         );
@@ -110,7 +116,8 @@ describe('transport info', () => {
                 headers: sinon.match({
                     'x-retry-count': '1'
                 }),
-                request: sinon.match({ query: 'hello' })
+                request: sinon.match({ query: 'hello' }),
+                requestSize: 109
             })
         );
 


### PR DESCRIPTION
We've recently had several downtimes where RAM consumption looked to be the issue, but we currently have no way to filter down which rabbitmq messages are particularily large.
