### PR TITLE
fix(dead letter): do not expect any response from dead letter qualifi…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -770,8 +770,8 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
                         );
                         return carotte.replyToPublisher(message, err, context, true);
                     })
-                .then(() => chan.ack(message))
-                .catch(() => chan.nack(message));
+                    .then(() => chan.ack(message))
+                    .catch(() => chan.nack(message));
             });
         };
     };
@@ -783,11 +783,14 @@ see doc: https://www.rabbitmq.com/reliability.html#consumer-side`);
      */
     carotte.saveDeadLetterIfNeeded = function saveDeadLetterIfNeeded(message, error) {
         if (config.enableDeadLetter) {
-            const headers = message.properties.headers;
             const content = JSON.parse(message.content.toString());
             content.context.error = serializeError(error);
 
-            headers['x-ignore-redeliver'] = true;
+            message.properties.headers['x-ignore-redeliver'] = true;
+            const headers = Object.assign({}, message.properties.headers);
+            // dead letter consumer should not generate a message for any consumer
+            delete headers['x-reply-to'];
+            delete headers['x-correlation-id'];
 
             // we use content buffer so we don't have to alter object structure
             // { data: , context: }

--- a/tests/dead-letter.spec.js
+++ b/tests/dead-letter.spec.js
@@ -1,31 +1,99 @@
 const expect = require('chai').expect;
-
-const carotte = require('./client')({
-    autoDescribe: false
-});
+const sinon = require('sinon');
+const Puid = require('puid');
+const carotteFactory = require('./client');
 
 const ERROR_MESSAGE = 'Woopsy!';
 
 describe('dead-letter', () => {
-    it('should send message in dead-letter queue when failing', (done) => {
-        carotte.subscribe('dead-letter', ({ context, headers }) => {
-            // we don't have a way to unsubscribe yet so we filter dead-letters
-            // that are sent in other tests using this condition
-            if (context.error.message !== ERROR_MESSAGE) {
-                return;
-            }
+    let uid;
+    let deadLetterQualifier;
+    let primaryCarotte;
+    let secondaryCarotte;
+    let deadLetterClient;
 
-            done();
-        })
-        .then(() => carotte.subscribe('direct/this-one-is-broken', () => {
+    beforeEach(() => {
+        uid = new Puid().generate();
+        deadLetterQualifier = `dead-letter-${uid}`;
+        primaryCarotte = carotteFactory({ serviceName: 'primary', autoDescribe: false, deadLetterQualifier });
+        secondaryCarotte = carotteFactory({ serviceName: 'secondary', autoDescribe: false, deadLetterQualifier });
+        deadLetterClient = carotteFactory({ serviceName: 'deadletter', autoDescribe: false, enableDeadLetter: false });
+    });
+
+    it('should send message in dead-letter queue when failing', async () => {
+        const deadLetterMock = sinon.stub().resolves();
+        await primaryCarotte.subscribe(deadLetterQualifier, deadLetterMock);
+
+        const brokenMock = sinon.stub().callsFake(() => {
             throw new Error(ERROR_MESSAGE);
-        }))
-        .then(() => carotte.invoke('direct/this-one-is-broken', {}))
-        .then(() => {
-            throw new Error('should not reach here');
-        }, err => {
-            // check that the consumer RPC queue received the right error
-            expect(err.message).to.eql(ERROR_MESSAGE);
         });
+        await primaryCarotte.subscribe(`direct/dead-letter-broken-handler-${uid}`, brokenMock);
+
+        try {
+            await primaryCarotte.invoke(`direct/dead-letter-broken-handler-${uid}`, {});
+            throw new Error('should throw');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(Error)
+                .and.to.have.property('message', ERROR_MESSAGE);
+        }
+
+        sinon.assert.calledOnce(deadLetterMock);
+        sinon.assert.calledWithExactly(deadLetterMock, sinon
+            .match(({ headers }) => {
+                return !headers['x-reply-to'];
+            }, 'header x-reply-to should not be defined')
+            .and(sinon.match(({ headers }) => {
+                return !headers['x-correlation-id'];
+            }, 'header x-correlation-id should not be defined'))
+        );
+        sinon.assert.callCount(brokenMock, 5 + 1);
+    });
+
+
+    it('should not forward dead letter response to original publisher', async () => {
+        // adding a delay to failing handler replyToPublisher in order
+        // to get dead letter message consumed first
+        const originalReplyToPublisher = secondaryCarotte.replyToPublisher;
+        sinon.stub(secondaryCarotte, 'replyToPublisher').callsFake(async (...args) => {
+            return new Promise((resolve) => {
+                setTimeout(() => {
+                    resolve(originalReplyToPublisher(...args));
+                }, 500);
+            });
+        });
+
+        const deadLetterMock = sinon.stub().resolves();
+        await deadLetterClient.subscribe(deadLetterQualifier, deadLetterMock);
+
+        const primaryMock = sinon.stub().callsFake(async () => {
+            return primaryCarotte.invoke(`direct/dead-letter-broken-handler-${uid}`, {});
+        });
+        await primaryCarotte.subscribe(`direct/dead-letter-primary-handler-${uid}`, primaryMock);
+
+        const brokenMock = sinon.stub().callsFake(() => {
+            throw new Error(ERROR_MESSAGE);
+        });
+        await secondaryCarotte.subscribe(`direct/dead-letter-broken-handler-${uid}`, brokenMock);
+
+        try {
+            await primaryCarotte.invoke(`direct/dead-letter-primary-handler-${uid}`, {});
+            throw new Error('should throw');
+        } catch (error) {
+            expect(error).to.be.an.instanceOf(Error)
+                .and.to.have.property('message', ERROR_MESSAGE);
+        }
+
+        sinon.assert.calledOnce(deadLetterMock);
+        sinon.assert.calledWithExactly(deadLetterMock, sinon
+            .match(({ headers }) => {
+                return !headers['x-reply-to'];
+            }, 'header x-reply-to should not be defined')
+            .and(sinon.match(({ headers }) => {
+                return !headers['x-correlation-id'];
+            }, 'header x-correlation-id should not be defined'))
+        );
+        sinon.assert.callCount(brokenMock, 5 + 1);
+        sinon.assert.calledOnce(primaryMock);
+        sinon.assert.calledOnce(secondaryCarotte.replyToPublisher);
     });
 });


### PR DESCRIPTION
…er to avoid concurrency issue

## Context

Once dead letter message is consumed, we currently forward failing call headers to dead letter service, thus the latter emits a creation success creation (when dead letter is saved in DB) and respond to initial caller x-reply-to & x-correlation-id being the same.

[Logs](https://app.datadoghq.com/logs?query=%40env%3Aproduction%20%40context.transactionId%3Alp9qoszb000f6b61cd2dy92r%20%40context.transactionStack%3AejlP&cols=%40env%2Cservice&index=main&messageDisplay=inline&refresh_mode=paused&saved-view-id=11782&stream_sort=time%2Casc&view=spans&viz=stream&from_ts=1700652155123&to_ts=1700660667438&live=false)
<img width="916" alt="image" src="https://github.com/cubyn/node-carotte-amqp/assets/8013026/af04e676-697f-4473-b762-f4f936c4eed9">

## Solution

Copy headers and remove x-correlation-id & x-reply-to